### PR TITLE
fix(#15): `XmirPath` replaces dots with slashes

### DIFF
--- a/src/main/java/org/eolang/ineo/XmirPath.java
+++ b/src/main/java/org/eolang/ineo/XmirPath.java
@@ -67,7 +67,7 @@ public class XmirPath extends ScalarEnvelope<Path> {
      * @param name Fire name without extension
      */
     public XmirPath(final Path home, final Text name) {
-        this(home, new Xmir(new Replaced(name, "\\.", File.separator)));
+        this(home, new Xmir(new Replaced(name, "\\.", "/")));
     }
 
     /**

--- a/src/main/java/org/eolang/ineo/XmirPath.java
+++ b/src/main/java/org/eolang/ineo/XmirPath.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.nio.file.Path;
 import org.cactoos.Text;
 import org.cactoos.scalar.ScalarEnvelope;
+import org.cactoos.text.Replaced;
 
 /**
  * Path to file with .xmir extension.
@@ -66,7 +67,7 @@ public class XmirPath extends ScalarEnvelope<Path> {
      * @param name Fire name without extension
      */
     public XmirPath(final Path home, final Text name) {
-        this(home, new Xmir(name));
+        this(home, new Xmir(new Replaced(name, "\\.", File.separator)));
     }
 
     /**

--- a/src/test/java/org/eolang/ineo/XmirPathTest.java
+++ b/src/test/java/org/eolang/ineo/XmirPathTest.java
@@ -47,16 +47,14 @@ final class XmirPathTest {
     }
 
     @Test
-    @Disabled
     void replacesDotsInGivenPath(@TempDir final Path temp) throws Exception {
         MatcherAssert.assertThat(
             "XmirPath should have replaced dot's in name with slashes, but it didn't",
             new XmirPath(temp, "org.eolang.main").value(),
-            Matchers.equalTo(
+            Matchers.is(
                 temp.resolve("org")
                     .resolve("eolang")
                     .resolve("main.xmir")
-                    .toString()
             )
         );
     }

--- a/src/test/java/org/eolang/ineo/XmirPathTest.java
+++ b/src/test/java/org/eolang/ineo/XmirPathTest.java
@@ -26,7 +26,6 @@ package org.eolang.ineo;
 import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 

--- a/src/test/java/org/eolang/ineo/XmirPathTest.java
+++ b/src/test/java/org/eolang/ineo/XmirPathTest.java
@@ -26,6 +26,7 @@ package org.eolang.ineo;
 import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 

--- a/src/test/java/org/eolang/ineo/optimization/OpInPlaceTest.java
+++ b/src/test/java/org/eolang/ineo/optimization/OpInPlaceTest.java
@@ -49,9 +49,8 @@ import org.junit.jupiter.api.io.TempDir;
  * Test cases for {@link OpInPlace}.
  * @since 0.0.1
  * @todo #12:30min Enable {@link OpInPlaceTest#replacesWithComplexNames(Path)} test. The test fails
- *  with FileNotFound exception because {@link XmirPath} is not able to build the right path with
- *  name that contains dots like "org.eolang.main". Need teach XmirPath to do it and enable the
- *  test. Don't forget to remove the puzzle.
+ *  with FileNotFound exception because {@link XmirPath} was not able to build the right path with
+ *  name that contains dots like "org.eolang.main". Don't forget to remove the puzzle.
  */
 @SuppressWarnings("PMD.TooManyMethods")
 final class OpInPlaceTest {


### PR DESCRIPTION
Closes: #15

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an issue in the XmirPath class where dots in the file name were not properly replaced with slashes. 

### Detailed summary
- Added the `org.cactoos.text.Replaced` import
- Modified the `XmirPath` constructor to replace dots in the file name with slashes using the `Replaced` class

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->