### PR TITLE
chore: Add Java 8 Support

### DIFF
--- a/.github/workflows/mvn.yaml
+++ b/.github/workflows/mvn.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2022, macos-12]
-        java: [11, 20]
+        java: [8, 11, 20]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ lighter EO code.
 
 # How to use
 
-To run the plugin you need at least Maven 3.1.+ and Java 11+.
+To run the plugin you need at least Maven 3.1.+ and Java 8+.
 The plugin provides two optimizations:
 
 ### FUSE 
@@ -154,4 +154,4 @@ before sending us your pull request please run full Maven build:
 $ mvn clean install -Pqulice
 ```
 
-You will need [Maven 3.3+](https://maven.apache.org) and Java 11+ installed.
+You will need [Maven 3.3+](https://maven.apache.org) and Java 8+ installed.

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@ SOFTWARE.
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.5.3</version>
+      <version>1.3.14</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,8 @@ SOFTWARE.
   </distributionManagement>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
     <maven.version>3.9.6</maven.version>
     <skipITs/>
   </properties>

--- a/src/it/factorial/pom.xml
+++ b/src/it/factorial/pom.xml
@@ -43,8 +43,8 @@ SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <jeo.version>0.4.4</jeo.version>
-    <opeo.version>0.2.0</opeo.version>
+    <jeo.version>0.4.6</jeo.version>
+    <opeo.version>0.2.2</opeo.version>
     <jeo.disassemble.output>${project.build.directory}/generated-sources/jeo-disassemble-xmir</jeo.disassemble.output>
     <opeo.decompile.output>${project.build.directory}/generated-sources/opeo-decompile-xmir</opeo.decompile.output>
     <opeo.modified>${project.build.directory}/generated-sources/opeo-decompile-modified-xmir</opeo.modified>

--- a/src/it/staticize-benchmark/src/main/xmir/org/eolang/benchmark/Main.xmir
+++ b/src/it/staticize-benchmark/src/main/xmir/org/eolang/benchmark/Main.xmir
@@ -128,11 +128,21 @@
                      <o base="string" data="bytes">64 35 65 39 30 31 37 33 2D 62 66 33 64 2D 34 64 66 38 2D 62 32 65 63 2D 31 34 39 65 63 32 30 61 65 37 37 62</o>
                   </o>
                   <o base="local3" scope="descriptor=J|type=LOAD"/>
-                  <o base=".get"
-                     scope="name=get|descriptor=()I|owner=org/eolang/benchmark/A|type=method">
-                     <o base=".new" scope="descriptor=(I)V">
-                        <o base="org/eolang/benchmark/A"/>
-                        <o base="int" data="bytes">00 00 00 00 00 00 00 2A</o>
+                  <o base=".get" scope="descriptor=()I|interfaced=false|name=get|owner=org/eolang/benchmark/A|type=method">
+                     <o base=".new" scope="descriptor=(I)V|interfaced=false">
+                        <o base="duplicated">
+                           <o base=".new-type">
+                              <o base="string" data="bytes">6F 72 67 2F 65 6F 6C 61 6E 67 2F 62 65 6E 63 68 6D 61 72 6B 2F 41</o>
+                           </o>
+                        </o>
+                        <o base=".minus">
+                           <o base=".get-field">
+                              <o base=".d" scope="descriptor=I|name=d|owner=org/eolang/benchmark/A|type=field">
+                                 <o base="$" scope="descriptor=org.eolang.benchmark.A"/>
+                              </o>
+                           </o>
+                           <o base="int" data="bytes">00 00 00 00 00 00 00 01</o>
+                        </o>
                      </o>
                   </o>
                   <o base="opcode" line="999" name="I2L">

--- a/src/it/staticize-with-opeo/pom.xml
+++ b/src/it/staticize-with-opeo/pom.xml
@@ -44,7 +44,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>opeo-maven-plugin</artifactId>
-        <version>0.1.10</version>
+        <version>0.2.2</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>

--- a/src/it/staticize-with-opeo/src/main/xmir/org/eolang/benchmark/A.xmir
+++ b/src/it/staticize-with-opeo/src/main/xmir/org/eolang/benchmark/A.xmir
@@ -57,6 +57,7 @@
                      <o base="string" data="bytes">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
                      <o base="string" data="bytes">3C 69 6E 69 74 3E</o>
                      <o base="string" data="bytes">28 29 56</o>
+                     <o base="bool" data="bytes">00</o>
                   </o>
                   <o base="label">
                      <o base="string" data="bytes">36 61 63 66 36 32 62 66 2D 31 66 66 30 2D 34 61 37 30 2D 61 61 66 66 2D 37 62 32 32 33 36 33 62 39 36 32 62</o>
@@ -160,12 +161,14 @@
                      <o base="string" data="bytes">6F 72 67 2F 65 6F 6C 61 6E 67 2F 62 65 6E 63 68 6D 61 72 6B 2F 41</o>
                      <o base="string" data="bytes">3C 69 6E 69 74 3E</o>
                      <o base="string" data="bytes">28 49 29 56</o>
+                     <o base="bool" data="bytes">00</o>
                   </o>
                   <o base="opcode" line="999" name="INVOKEVIRTUAL-27">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 B6</o>
                      <o base="string" data="bytes">6F 72 67 2F 65 6F 6C 61 6E 67 2F 62 65 6E 63 68 6D 61 72 6B 2F 41</o>
                      <o base="string" data="bytes">67 65 74</o>
                      <o base="string" data="bytes">28 29 49</o>
+                     <o base="bool" data="bytes">00</o>
                   </o>
                   <o base="opcode" line="999" name="IRETURN-28">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 AC</o>

--- a/src/it/staticize-with-opeo/src/main/xmir/org/eolang/benchmark/Main.xmir
+++ b/src/it/staticize-with-opeo/src/main/xmir/org/eolang/benchmark/Main.xmir
@@ -50,6 +50,7 @@
                      <o base="string" data="bytes">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
                      <o base="string" data="bytes">3C 69 6E 69 74 3E</o>
                      <o base="string" data="bytes">28 29 56</o>
+                     <o base="bool" data="bytes">00</o>
                   </o>
                   <o base="opcode" line="999" name="RETURN-2B">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 B1</o>
@@ -86,6 +87,7 @@
                      <o base="string" data="bytes">6A 61 76 61 2F 6C 61 6E 67 2F 4C 6F 6E 67</o>
                      <o base="string" data="bytes">70 61 72 73 65 4C 6F 6E 67</o>
                      <o base="string" data="bytes">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 4A</o>
+                     <o base="bool" data="bytes">00</o>
                   </o>
                   <o base="opcode" line="999" name="LSTORE-30">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 37</o>
@@ -109,6 +111,7 @@
                      <o base="string" data="bytes">6A 61 76 61 2F 6C 61 6E 67 2F 53 79 73 74 65 6D</o>
                      <o base="string" data="bytes">63 75 72 72 65 6E 74 54 69 6D 65 4D 69 6C 6C 69 73</o>
                      <o base="string" data="bytes">28 29 4A</o>
+                     <o base="bool" data="bytes">00</o>
                   </o>
                   <o base="opcode" line="999" name="LSTORE-34">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 37</o>
@@ -167,12 +170,14 @@
                      <o base="string" data="bytes">6F 72 67 2F 65 6F 6C 61 6E 67 2F 62 65 6E 63 68 6D 61 72 6B 2F 41</o>
                      <o base="string" data="bytes">3C 69 6E 69 74 3E</o>
                      <o base="string" data="bytes">28 49 29 56</o>
+                     <o base="bool" data="bytes">00</o>
                   </o>
                   <o base="opcode" line="999" name="INVOKEVIRTUAL-40">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 B6</o>
                      <o base="string" data="bytes">6F 72 67 2F 65 6F 6C 61 6E 67 2F 62 65 6E 63 68 6D 61 72 6B 2F 41</o>
                      <o base="string" data="bytes">67 65 74</o>
                      <o base="string" data="bytes">28 29 49</o>
+                     <o base="bool" data="bytes">00</o>
                   </o>
                   <o base="opcode" line="999" name="I2L-41">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 85</o>
@@ -242,6 +247,7 @@
                      <o base="string" data="bytes">6A 61 76 61 2F 6C 61 6E 67 2F 4C 6F 6E 67</o>
                      <o base="string" data="bytes">76 61 6C 75 65 4F 66</o>
                      <o base="string" data="bytes">28 4A 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4C 6F 6E 67 3B</o>
+                     <o base="bool" data="bytes">00</o>
                   </o>
                   <o base="opcode" line="999" name="AASTORE-51">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 53</o>
@@ -257,6 +263,7 @@
                      <o base="string" data="bytes">6A 61 76 61 2F 6C 61 6E 67 2F 53 79 73 74 65 6D</o>
                      <o base="string" data="bytes">63 75 72 72 65 6E 74 54 69 6D 65 4D 69 6C 6C 69 73</o>
                      <o base="string" data="bytes">28 29 4A</o>
+                     <o base="bool" data="bytes">00</o>
                   </o>
                   <o base="opcode" line="999" name="LLOAD-55">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 16</o>
@@ -270,6 +277,7 @@
                      <o base="string" data="bytes">6A 61 76 61 2F 6C 61 6E 67 2F 4C 6F 6E 67</o>
                      <o base="string" data="bytes">76 61 6C 75 65 4F 66</o>
                      <o base="string" data="bytes">28 4A 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4C 6F 6E 67 3B</o>
+                     <o base="bool" data="bytes">00</o>
                   </o>
                   <o base="opcode" line="999" name="AASTORE-58">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 53</o>
@@ -279,6 +287,7 @@
                      <o base="string" data="bytes">6A 61 76 61 2F 69 6F 2F 50 72 69 6E 74 53 74 72 65 61 6D</o>
                      <o base="string" data="bytes">70 72 69 6E 74 66</o>
                      <o base="string" data="bytes">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B 29 4C 6A 61 76 61 2F 69 6F 2F 50 72 69 6E 74 53 74 72 65 61 6D 3B</o>
+                     <o base="bool" data="bytes">00</o>
                   </o>
                   <o base="opcode" line="999" name="POP-5A">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 57</o>

--- a/src/main/resources/org/eolang/ineo/fuse/BA.xmir
+++ b/src/main/resources/org/eolang/ineo/fuse/BA.xmir
@@ -55,6 +55,7 @@
                      <o base="string" data="bytes">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
                      <o base="string" data="bytes">3C 69 6E 69 74 3E</o>
                      <o base="string" data="bytes">28 29 56</o>
+                     <o base="bool" data="bytes">00</o>
                   </o>
                   <o base="label" data="bytes">61 30 34 65 32 61 37 64 2D 35 38 65 33 2D 34 61 63 30 2D 38 63 32 37 2D 34 38 33 38 39 64 38 62 62 34 34 32</o>
                   <o base="opcode" line="999" name="ALOAD-F">
@@ -106,6 +107,7 @@
                      <o base="string" data="bytes">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
                      <o base="string" data="bytes">68 61 73 68 43 6F 64 65</o>
                      <o base="string" data="bytes">28 29 49</o>
+                     <o base="bool" data="bytes">00</o>
                   </o>
                   <o base="opcode" line="999" name="IADD-17">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 60</o>
@@ -134,6 +136,7 @@
                      <o base="string" data="bytes">6F 72 67 2F 65 6F 6C 61 6E 67 2F 62 65 6E 63 68 6D 61 72 6B 2F 42 41</o>
                      <o base="string" data="bytes">66 6F 6F</o>
                      <o base="string" data="bytes">28 29 49</o>
+                     <o base="bool" data="bytes">00</o>
                   </o>
                   <o base="opcode" line="999" name="ICONST_2-1B">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 05</o>

--- a/src/main/resources/org/eolang/ineo/staticize/StaticizedA.xmir
+++ b/src/main/resources/org/eolang/ineo/staticize/StaticizedA.xmir
@@ -55,6 +55,7 @@
                      <o base="string" data="bytes">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
                      <o base="string" data="bytes">3C 69 6E 69 74 3E</o>
                      <o base="string" data="bytes">28 29 56</o>
+                     <o base="bool" data="bytes">00</o>
                   </o>
                   <o base="label" data="bytes">61 39 32 32 66 34 63 64 2D 31 36 34 61 2D 34 61 37 32 2D 38 66 36 66 2D 64 32 64 31 37 36 37 37 39 35 33 31</o>
                   <o base="opcode" line="999" name="ALOAD-3">
@@ -102,6 +103,7 @@
                      <o base="string" data="bytes">6F 72 67 2F 65 6F 6C 61 6E 67 2F 62 65 6E 63 68 6D 61 72 6B 2F 53 74 61 74 69 63 69 7A 65 64 41</o>
                      <o base="string" data="bytes">78 67 65 74</o>
                      <o base="string" data="bytes">28 49 29 49</o>
+                     <o base="bool" data="bytes">00</o>
                   </o>
                   <o base="opcode" line="999" name="IRETURN-A">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 AC</o>
@@ -151,6 +153,7 @@
                      <o base="string" data="bytes">6F 72 67 2F 65 6F 6C 61 6E 67 2F 62 65 6E 63 68 6D 61 72 6B 2F 53 74 61 74 69 63 69 7A 65 64 41</o>
                      <o base="string" data="bytes">78 67 65 74</o>
                      <o base="string" data="bytes">28 49 29 49</o>
+                     <o base="bool" data="bytes">00</o>
                   </o>
                   <o base="opcode" line="999" name="IRETURN-13">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 AC</o>

--- a/src/main/resources/org/eolang/ineo/staticize/staticize.xsl
+++ b/src/main/resources/org/eolang/ineo/staticize/staticize.xsl
@@ -24,21 +24,23 @@ SOFTWARE.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="staticize" version="2.0">
   <xsl:output encoding="UTF-8" method="xml"/>
-  <!--
-  <o base=".get" scope="name=get|descriptor=()I|owner=org/eolang/benchmark/A|type=method">
-     <o base=".new" scope="descriptor=(I)V">
-        <o base="org/eolang/benchmark/A"/>
-        <o base="int" data="bytes">00 00 00 00 00 00 00 2A</o>
-     </o>
-  </o>
-  -->
-  <xsl:template match="//o[@base='.get' and @scope and o[1][@base='.new' and o[1][@base='org/eolang/benchmark/A']]]">
-    <o base=".get" scope="name=get|descriptor=()I|owner=org/eolang/benchmark/StaticizedA|type=method">
-      <o base=".new" scope="descriptor=(I)V">
-        <o base="org/eolang/benchmark/StaticizedA"/>
-        <xsl:copy-of select="./o[position()=1]/o[position()&gt;1]"/>
+  <xsl:template match="//o[@base='.get' and @scope='descriptor=()I|interfaced=false|name=get|owner=org/eolang/benchmark/A|type=method']">
+    <o base=".get" scope="descriptor=()I|interfaced=false|name=get|owner=org/eolang/benchmark/StaticizedA|type=method">
+      <o base=".new" scope="descriptor=(I)V|interfaced=false">
+        <o base="duplicated">
+          <o base=".new-type">
+            <o base="string" data="bytes">6F 72 67 2F 65 6F 6C 61 6E 67 2F 62 65 6E 63 68 6D 61 72 6B 2F 53 74 61 74 69 63 69 7A 65 64 41</o>
+          </o>
+        </o>
+        <o base=".minus">
+          <o base=".get-field">
+            <o base=".d" scope="descriptor=I|name=d|owner=org/eolang/benchmark/StaticizedA|type=field">
+              <o base="$" scope="descriptor=org.eolang.benchmark.StaticizedA"/>
+            </o>
+          </o>
+          <o base="int" data="bytes">00 00 00 00 00 00 00 01</o>
+        </o>
       </o>
-      <xsl:copy-of select="./o[position()&gt;1]"/>
     </o>
   </xsl:template>
   <!-- Ignore other elements -->


### PR DESCRIPTION
We need to support Java 8. `jeo-maven-plugin` and `opeo-maven-plugin` use `ineo-maven-plugin` and they support Java 8.
Since the plugins depends on `ineo-maven-plugin` they require from `ineo-maven-plugin` to support Java 8 as well.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for Java 8 alongside existing versions in the Maven build workflow. It also updates Java and plugin versions, compiler settings, and dependencies.

### Detailed summary
- Added Java 8 support in the Maven build workflow
- Updated Java and plugin versions
- Modified compiler settings in `pom.xml`
- Updated dependencies versions in the project

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->