### PR TITLE
chore: speed up rultor by using fast image

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -1,7 +1,7 @@
 architect:
   - maxonfjvipon
 docker:
-  image: yegor256/rultor-image:1.19.0
+  image: lombrozo/rultor-image-java:pr-3
 assets:
   settings.xml: yegor256/objectionary-secrets#settings.xml
   pubring.gpg: yegor256/objectionary-secrets#pubring.gpg
@@ -12,6 +12,8 @@ release:
   pre: false
   script: |-
     echo "Master branch"
+    export MAVEN_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED"
+    echo "MAVEN_OPTS: $MAVEN_OPTS"
     [[ "${tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit -1
     mvn versions:set "-DnewVersion=${tag}" 
     git commit -am "${tag}"


### PR DESCRIPTION
In this pr I used `lombrozo/rultor-image-java:pr-3` image for rultor.
The previous rultor run took around 28 minutes.
With the new image rultor runs will take around 6 minutes in average (depending on integration tests in the project).


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Docker image in `.rultor.yml` and adds `MAVEN_OPTS` in the release script.

### Detailed summary
- Updated Docker image to `lombrozo/rultor-image-java:pr-3`
- Added `MAVEN_OPTS` in the release script to configure Java module access restrictions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->